### PR TITLE
Use Correct Content-Type

### DIFF
--- a/user_xrds.php
+++ b/user_xrds.php
@@ -18,7 +18,7 @@ if (!isset($_GET['id']) || preg_match('/^\d+$/', $_GET['id']) !== 1) {
 
 /* This XRD is shorter than described in the doc since we don't sign the XML */
 
-header('Content-Type: application/xml+xrds');
+header('Content-Type: application/xrds+xml');
 print '<?xml version="1.0" encoding="UTF-8"?>';
 
 ?>


### PR DESCRIPTION
Updates openid.php to use the correct Content-Type ("application/xrds+xml") when returning an XRDS (https://en.wikipedia.org/wiki/XRDS#Example_XRDS_document)
